### PR TITLE
Fixing On_LandmineExploded hook

### DIFF
--- a/Pluton.Patcher.Rust.json
+++ b/Pluton.Patcher.Rust.json
@@ -508,7 +508,7 @@
 					"OpCode": "Call",
 					"InstructionType": "InsertBefore",
 					"OperandType": "Method",
-					"InsertOffset": "34",
+					"InsertOffset": "36",
 					"TargetMethod": "On_LandmineExploded",
 					"TargetType": "Pluton.Rust.Hooks",
 					"TargetAssembly": "Pluton.Rust.dll"
@@ -516,7 +516,7 @@
 					"OpCode": "Ldarg_0",
 					"InstructionType": "InsertBefore",
 					"OperandType": "None",
-					"InsertOffset": "34"
+					"InsertOffset": "36"
 				}]
 			}, {
 				"TargetMethod": "Trigger",


### PR DESCRIPTION
Fixing On_LandmineExploded hook, it was missplaced by 2 lines. Probably assembly code in rust changed at some point.
